### PR TITLE
Logging the migrations in the SequelizeMeta table (This works)

### DIFF
--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -51,7 +51,7 @@ var SequelizeMeta = sequelize.define(tableName, {
     }
 });
 
-sequelize.query("CREATE TABLE sequelize_meta (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
+sequelize.query("CREATE TABLE SequelizeMeta (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
 
 var already_uploaded = [];
 try {

--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -51,14 +51,14 @@ var SequelizeMeta = sequelize.define(tableName, {
     }
 });
 
-sequelize.query("
-  CREATE TABLE \"SequelizeMeta\" (name character varying(255) NOT NULL);
-  ALTER TABLE ONLY \"SequelizeMeta\" ADD CONSTRAINT \"SequelizeMeta_pkey\" PRIMARY KEY (name);
-");
+sequelize.query(`
+  CREATE TABLE "SequelizeMeta" (name character varying(255) NOT NULL);
+  ALTER TABLE ONLY "SequelizeMeta" ADD CONSTRAINT "SequelizeMeta_pkey" PRIMARY KEY (name);
+`);
 
 var already_uploaded = [];
 try {
-    sequelize.query("SELECT * FROM \"SequelizeMeta\"", { type: sequelize.QueryTypes.SELECT })
+    sequelize.query(`SELECT * FROM "SequelizeMeta"`, { type: sequelize.QueryTypes.SELECT })
         .then(users => {
        for(var key in users){
            already_uploaded[users[key].name] = true ;
@@ -107,7 +107,7 @@ Async.eachSeries(migrationFiles,
             if (stop)
                 return cb("Stopped");
             if(!err){
-                sequelize.query("INSERT INTO \"SequelizeMeta\" (name ) VALUES ( ? )",
+                sequelize.query(`INSERT INTO "SequelizeMeta" (name ) VALUES ( ? )`,
                      { replacements: [file] }).spread((results, metadata) => {
                 });
             }

--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -40,7 +40,7 @@ let fromRevision = options.rev;
 let fromPos = parseInt(options.pos);
 let stop = options.one;
 
-var tableName = 'sequelize_meta' ;
+var tableName = 'SequelizeMeta' ;
 var SequelizeMeta = sequelize.define(tableName, {
     name: {
         type: Sequelize.STRING,
@@ -51,11 +51,11 @@ var SequelizeMeta = sequelize.define(tableName, {
     }
 });
 
-sequelize.query("CREATE TABLE sequelize_meta (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
+sequelize.query("CREATE TABLE \"SequelizeMeta\" (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
 
 var already_uploaded = [];
 try {
-    sequelize.query("SELECT * FROM sequelize_meta", { type: sequelize.QueryTypes.SELECT })
+    sequelize.query("SELECT * FROM \"SequelizeMeta\"", { type: sequelize.QueryTypes.SELECT })
         .then(users => {
        for(var key in users){
            already_uploaded[users[key].name] = true ;
@@ -104,7 +104,7 @@ Async.eachSeries(migrationFiles,
             if (stop)
                 return cb("Stopped");
             if(!err){
-                sequelize.query("INSERT INTO sequelize_meta (name ) VALUES ( ? )",
+                sequelize.query("INSERT INTO \"SequelizeMeta\" (name ) VALUES ( ? )",
                      { replacements: [file] }).spread((results, metadata) => {
                 });
             }

--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -51,11 +51,11 @@ var SequelizeMeta = sequelize.define(tableName, {
     }
 });
 
-sequelize.query("CREATE TABLE `SequelizeMeta` (   `name` varchar(255) NOT NULL,   PRIMARY KEY (`name`),   UNIQUE KEY `name` (`name`),  UNIQUE KEY `SequelizeMeta_name_unique` (`name`) )");
+sequelize.query("CREATE TABLE sequelize_meta (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
 
 var already_uploaded = [];
 try {
-    sequelize.query("SELECT * FROM `SequelizeMeta`", { type: sequelize.QueryTypes.SELECT })
+    sequelize.query("SELECT * FROM SequelizeMeta", { type: sequelize.QueryTypes.SELECT })
         .then(users => {
        for(var key in users){
            already_uploaded[users[key].name] = true ;

--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -51,7 +51,10 @@ var SequelizeMeta = sequelize.define(tableName, {
     }
 });
 
-sequelize.query("CREATE TABLE \"SequelizeMeta\" (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
+sequelize.query("
+  CREATE TABLE \"SequelizeMeta\" (name character varying(255) NOT NULL);
+  ALTER TABLE ONLY \"SequelizeMeta\" ADD CONSTRAINT \"SequelizeMeta_pkey\" PRIMARY KEY (name);
+");
 
 var already_uploaded = [];
 try {

--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -1,128 +1,115 @@
 #!/bin/node
 
-const path              = require("path");
-const commandLineArgs   = require('command-line-args');
-const fs                = require("fs");
-const Async             = require("async");
+const path = require('path');
+const commandLineArgs = require('command-line-args');
+const fs = require('fs');
+const Async = require('async');
+const Sequelize = require('sequelize');
+const migrate = require('../lib/migrate');
 
-const migrate           = require("../lib/migrate");
-
-let migrationsDir = path.join(process.env.PWD, 'migrations'),
-    modelsDir     = path.join(process.env.PWD, 'models');
+const migrationsDir = path.join(process.env.PWD, 'migrations');
+const modelsDir = path.join(process.env.PWD, 'models');
 
 const optionDefinitions = [
-    { name: 'rev', alias: 'r', type: Number, description: 'Set migration revision (default: 0)', defaultValue: 0 },
-    { name: 'pos', alias: 'p', type: Number, description: 'Run first migration at pos (default: 0)', defaultValue: 0 },
-    { name: 'one', type: Boolean, description: 'Do not run next migrations', defaultValue: false },
-    { name: 'list', alias: 'l', type: Boolean, description: 'Show migration file list (without execution)', defaultValue: false },
-    { name: 'help', type: Boolean, description: 'Show this message' }
+  {
+    name: 'rev', alias: 'r', type: Number, description: 'Set migration revision (default: 0)', defaultValue: 0,
+  },
+  {
+    name: 'pos', alias: 'p', type: Number, description: 'Run first migration at pos (default: 0)', defaultValue: 0,
+  },
+  {
+    name: 'one', type: Boolean, description: 'Do not run next migrations', defaultValue: false,
+  },
+  {
+    name: 'list', alias: 'l', type: Boolean, description: 'Show migration file list (without execution)', defaultValue: false,
+  },
+  { name: 'help', type: Boolean, description: 'Show this message' },
 ];
 
 const options = commandLineArgs(optionDefinitions);
 
 
-if (options.help)
-{
-    console.log("Simple sequelize migration execution tool\n\nUsage:");
-    optionDefinitions.forEach((option) => {
-        let alias = (option.alias) ? ` (-${option.alias})` : '\t';
-        console.log(`\t --${option.name}${alias} \t${option.description}`);
-    });
-    process.exit(0);
+if (options.help) {
+  console.log('Simple sequelize migration execution tool\n\nUsage:');
+  optionDefinitions.forEach((option) => {
+    const alias = (option.alias) ? ` (-${option.alias})` : '\t';
+    console.log(`\t --${option.name}${alias} \t${option.description}`);
+  });
+  process.exit(0);
 }
 
-const Sequelize = require("sequelize");
-const sequelize = require(modelsDir).sequelize;
+const { sequelize } = require(modelsDir);
 const queryInterface = sequelize.getQueryInterface();
 
 // execute all migration from
-let fromRevision = options.rev;
-let fromPos = parseInt(options.pos);
-let stop = options.one;
+const fromRevision = options.rev;
+let fromPos = parseInt(options.pos, 10);
+const stop = options.one;
 
-var tableName = 'SequelizeMeta' ;
-var SequelizeMeta = sequelize.define(tableName, {
-    name: {
-        type: Sequelize.STRING,
-        allowNull: false,
-        unique: true,
-        primaryKey: true,
-        autoIncrement: false
-    }
-});
-
-sequelize.query(`
-  CREATE TABLE "SequelizeMeta" (name character varying(255) NOT NULL);
-  ALTER TABLE ONLY "SequelizeMeta" ADD CONSTRAINT "SequelizeMeta_pkey" PRIMARY KEY (name);
-`);
-
-var already_uploaded = [];
-try {
-    sequelize.query(`SELECT * FROM "SequelizeMeta"`, { type: sequelize.QueryTypes.SELECT })
-        .then(users => {
-       for(var key in users){
-           already_uploaded[users[key].name] = true ;
-       }
-
-let migrationFiles = fs.readdirSync(migrationsDir)
-// filter JS files
-  .filter((file) => {
-    return (file.indexOf('.') !== 0) && (file.slice(-3) === '.js');
-  })
-// sort by revision
-  .sort( (a, b) => {
-      let revA = parseInt( path.basename(a).split('-',2)[0]),
-          revB = parseInt( path.basename(b).split('-',2)[0]);
-      if (revA < revB) return -1;
-      if (revA > revB) return 1;
-      return 0;
-  })
-// remove all migrations before fromRevision
-  .filter((file) => {
-      let rev = parseInt( path.basename(file).split('-',2)[0]);
-      return (rev >= fromRevision);
-      //return false ;
-  })
-
-.filter((file) => {
-        return already_uploaded[file] != true ;
-}) ;
-// remove all migations which have already been loaded
-
-
-
-console.log("Migrations to execute:");
-migrationFiles.forEach((file) => {
-    console.log("\t"+file);
-});
-
-if (options.list)
-    process.exit(0);
-
-
-Async.eachSeries(migrationFiles,
-    function (file, cb) {
-        console.log("Execute migration from file: "+file);
-        migrate.executeMigration(queryInterface, path.join(migrationsDir, file), fromPos, (err) => {
-            if (stop)
-                return cb("Stopped");
-            if(!err){
-                sequelize.query(`INSERT INTO "SequelizeMeta" (name ) VALUES ( ? )`,
-                     { replacements: [file] }).spread((results, metadata) => {
-                });
-            }
-            cb(err);
+queryInterface.createTable('SequelizeMeta', {
+  name: {
+    type: Sequelize.STRING,
+    allowNull: false,
+    unique: true,
+    primaryKey: true,
+  },
+}).then(() => {
+  const alreadyExecuted = [];
+  try {
+    sequelize.query('SELECT * FROM "SequelizeMeta"', { type: sequelize.QueryTypes.SELECT })
+      .then((scripts) => {
+        (scripts || []).forEach((script) => {
+          alreadyExecuted[script.name] = true;
         });
-        // set pos to 0 for next migration
-        fromPos = 0;
-    },
-    function(err) {
-        console.log(err);
-        process.exit(0);
-    }
-);
+        const migrationFiles = fs.readdirSync(migrationsDir)
+          .filter(file => (file.indexOf('.') !== 0) && (file.slice(-3) === '.js'))
+          .sort((a, b) => {
+            const revA = parseInt(path.basename(a).split('-', 2)[0], 10);
+            const revB = parseInt(path.basename(b).split('-', 2)[0], 10);
+            if (revA < revB) return -1;
+            if (revA > revB) return 1;
+            return 0;
+          })
+          .filter((file) => {
+            const rev = parseInt(path.basename(file).split('-', 2)[0], 10);
+            return (rev >= fromRevision);
+          })
+          .filter(file => alreadyExecuted[file] !== true);
+        console.log('Migrations to execute:');
+        migrationFiles.forEach((file) => {
+          console.log(`\t${file}`);
+        });
 
-});
-} catch (e){
+        if (options.list) { process.exit(0); }
+        Async.eachSeries(
+          migrationFiles, (file, cb) => {
+            console.log(`Execute migration from file: ${file}`);
+            migrate.executeMigration(
+              queryInterface, path.join(migrationsDir, file), fromPos,
+              (err) => {
+                if (stop) { return cb('Stopped'); }
+                if (!err) {
+                  return queryInterface.bulkInsert('SequelizeMeta', [{
+                    name: file,
+                  }]).then(() => cb()).catch(error => cb(error));
+                }
+                return cb(err);
+              },
+            );
+            // set pos to 0 for next migration
+            fromPos = 0;
+          },
+          (err) => {
+            if (err) {
+              console.log(err);
+            }
+            process.exit(0);
+          },
+        );
+      }).catch(error => console.log(error));
+  } catch (e) {
     console.log(e);
-}
+  }
+}).catch((error) => {
+  console.log(error);
+});

--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -7,20 +7,19 @@ const Async             = require("async");
 
 const migrate           = require("../lib/migrate");
 
+let migrationsDir = path.join(process.env.PWD, 'migrations'),
+    modelsDir     = path.join(process.env.PWD, 'models');
+
 const optionDefinitions = [
     { name: 'rev', alias: 'r', type: Number, description: 'Set migration revision (default: 0)', defaultValue: 0 },
     { name: 'pos', alias: 'p', type: Number, description: 'Run first migration at pos (default: 0)', defaultValue: 0 },
     { name: 'one', type: Boolean, description: 'Do not run next migrations', defaultValue: false },
     { name: 'list', alias: 'l', type: Boolean, description: 'Show migration file list (without execution)', defaultValue: false },
-    { name: 'migrations-path', type: String, description: 'The path to the migrations folder' },
-    { name: 'models-path', type: String, description: 'The path to the models folder' },
     { name: 'help', type: Boolean, description: 'Show this message' }
 ];
 
 const options = commandLineArgs(optionDefinitions);
 
-let migrationsDir = path.join(process.env.PWD, options['migrations-path'] || 'migrations'),
-    modelsDir     = path.join(process.env.PWD, options['models-path'] || 'models');
 
 if (options.help)
 {
@@ -41,6 +40,27 @@ let fromRevision = options.rev;
 let fromPos = parseInt(options.pos);
 let stop = options.one;
 
+var tableName = 'SequelizeMeta' ;
+var SequelizeMeta = sequelize.define(tableName, {
+    name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true,
+        primaryKey: true,
+        autoIncrement: false
+    }
+});
+
+sequelize.query("CREATE TABLE `SequelizeMeta` (   `name` varchar(255) NOT NULL,   PRIMARY KEY (`name`),   UNIQUE KEY `name` (`name`),  UNIQUE KEY `SequelizeMeta_name_unique` (`name`) )");
+
+var already_uploaded = [];
+try {
+    sequelize.query("SELECT * FROM `SequelizeMeta`", { type: sequelize.QueryTypes.SELECT })
+        .then(users => {
+       for(var key in users){
+           already_uploaded[users[key].name] = true ;
+       }
+
 let migrationFiles = fs.readdirSync(migrationsDir)
 // filter JS files
   .filter((file) => {
@@ -58,9 +78,17 @@ let migrationFiles = fs.readdirSync(migrationsDir)
   .filter((file) => {
       let rev = parseInt( path.basename(file).split('-',2)[0]);
       return (rev >= fromRevision);
-  });
-  
-console.log("Migrations to execute:");  
+      //return false ;
+  })
+
+.filter((file) => {
+        return already_uploaded[file] != true ;
+}) ;
+// remove all migations which have already been loaded
+
+
+
+console.log("Migrations to execute:");
 migrationFiles.forEach((file) => {
     console.log("\t"+file);
 });
@@ -69,13 +97,17 @@ if (options.list)
     process.exit(0);
 
 
-Async.eachSeries(migrationFiles, 
+Async.eachSeries(migrationFiles,
     function (file, cb) {
         console.log("Execute migration from file: "+file);
         migrate.executeMigration(queryInterface, path.join(migrationsDir, file), fromPos, (err) => {
             if (stop)
                 return cb("Stopped");
-                
+            if(!err){
+                sequelize.query("INSERT INTO SequelizeMeta (name ) VALUES ( ? )",
+                     { replacements: [file] }).spread((results, metadata) => {
+                });
+            }
             cb(err);
         });
         // set pos to 0 for next migration
@@ -86,3 +118,8 @@ Async.eachSeries(migrationFiles,
         process.exit(0);
     }
 );
+
+});
+} catch (e){
+    console.log(e);
+}

--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -40,7 +40,7 @@ let fromRevision = options.rev;
 let fromPos = parseInt(options.pos);
 let stop = options.one;
 
-var tableName = 'SequelizeMeta' ;
+var tableName = 'sequelize_meta' ;
 var SequelizeMeta = sequelize.define(tableName, {
     name: {
         type: Sequelize.STRING,
@@ -51,11 +51,11 @@ var SequelizeMeta = sequelize.define(tableName, {
     }
 });
 
-sequelize.query("CREATE TABLE SequelizeMeta (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
+sequelize.query("CREATE TABLE sequelize_meta (name varchar(255) NOT NULL PRIMARY KEY UNIQUE)");
 
 var already_uploaded = [];
 try {
-    sequelize.query("SELECT * FROM SequelizeMeta", { type: sequelize.QueryTypes.SELECT })
+    sequelize.query("SELECT * FROM sequelize_meta", { type: sequelize.QueryTypes.SELECT })
         .then(users => {
        for(var key in users){
            already_uploaded[users[key].name] = true ;
@@ -104,7 +104,7 @@ Async.eachSeries(migrationFiles,
             if (stop)
                 return cb("Stopped");
             if(!err){
-                sequelize.query("INSERT INTO SequelizeMeta (name ) VALUES ( ? )",
+                sequelize.query("INSERT INTO sequelize_meta (name ) VALUES ( ? )",
                      { replacements: [file] }).spread((results, metadata) => {
                 });
             }


### PR DESCRIPTION
Hi I looked into Thedeceptio's pull request about logging the migrations on the sequelizeMeta table but did not work due to several asynchronous bugs, I went ahead and fixed all of them and now when you launch runmigration.js, if not exists, it will create the table and log the script names there, next time you try to run more migrations the script will ignore those that were already executed