### PR TITLE
support to precision and scale in NUMBER types

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -60,6 +60,15 @@ const reverseSequelizeColType = function(col, prefix = 'Sequelize.')
                 ret += ', ' + options.decimals;
             ret += ')';
         }
+
+
+        if (options.precision) {
+            ret += '('+options.precision;
+            if (options.scale)
+                ret += ', ' + options.scale;
+            ret += ')';
+        }
+
         
         ret = [ ret ];
 


### PR DESCRIPTION
With this update, you can define models with Decimal datatype informing precision and scale like in this example below: 
`sequelize.define('IndicatorDetail', {
        id: {
            type: DataTypes.INTEGER,
            allowNull: false,
            primaryKey: true,
            autoIncrement: true
        },
        time: {
            type: DataTypes.DATE
        },
        plan: {
            type: DataTypes.DECIMAL(16, 4)
        },{});
`
and the script can generate precision and scale on migration file like this:

`{
        fn: "createTable",
        params: [
            "IndicatorDetails",
            {
                "id": {
                    "type": Sequelize.INTEGER,
                    "autoIncrement": true,
                    "primaryKey": true,
                    "allowNull": false
                },
                "time": {
                    "type": Sequelize.DATE
                },
                "plan": {
                    "type": Sequelize.DECIMAL(16, 4)
                },... ` 
