### PR TITLE
Migration generation: Add column and change column not considering op…

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -403,6 +403,7 @@ const parseDifference = function(previousState, currentState)
                             actionType: 'removeColumn',
                             tableName: tableName,
                             columnName: df.path[2],
+                            options: df.lhs,
                             depends: [ tableName ]
                         });
                         break;
@@ -648,10 +649,10 @@ let resUp = `{ fn: "addColumn", params: [
 
             case 'removeColumn':
             {
-                let res = `{ fn: "removeColumn", params: ["${action.tableName}", "${action.columnName}"] }`;
+                let res = `{ fn: "removeColumn", params: ["${action.tableName}", "${!action.options.field ? action.columnName : action.options.field}"] }`;
                 commandsUp.push(res);
                 
-                consoleOut.push(`removeColumn "${action.columnName}" from table "${action.tableName}"`);
+                consoleOut.push(`removeColumn "${!action.options.field ? action.columnName : action.options.field}" from table "${action.tableName}"`);
             }
             break;
             

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -189,7 +189,8 @@ const reverseModels = function(sequelize, models)
         {
             delete attributes[column].Model;
             delete attributes[column].fieldName;
-            delete attributes[column].field;
+            // COMMENTED - to create column name with underscores
+            // delete attributes[column].field;
             
             for(let property in attributes[column]) 
             {
@@ -635,7 +636,7 @@ let resUp =`{ fn: "createTable", params: [
             {
 let resUp = `{ fn: "addColumn", params: [
     "${action.tableName}",
-    "${action.attributeName}",
+    "${!action.options.field ? action.attributeName : action.options.field}",
     ${propertyToStr(action.options)}
 ] }`;
 
@@ -658,7 +659,7 @@ let resUp = `{ fn: "addColumn", params: [
             {
 let res = `{ fn: "changeColumn", params: [
     "${action.tableName}",
-    "${action.attributeName}",
+    "${!action.options.field ? action.attributeName : action.options.field}",
     ${propertyToStr(action.options)}
 ] }`;
                 commandsUp.push(res);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sequelize-auto-migrations",
+  "name": "sequelize-auto-migrations-fix",
   "version": "1.0.0",
   "description": "Sequelize migrations generator && runner",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/flexxnn/sequelize-auto-migrations.git"
+    "url": "git+https://github.com/Sreemanth/sequelize-auto-migrations.git"
   },
   "keywords": [
     "sequelize",


### PR DESCRIPTION
#### Issue

**Add column** and **change column** not considering _**options.field**_ of sequelize definition

In below definition _campaignType_ column should create  _campaign_type_ rather than this _campaignType_

```js
export default (sequelize, DataTypes)=> {
	const Campaign= sequelize.define('campaign', {
		id: {
			type: DataTypes.BIGINT,
			allowNull: false,
			primaryKey: true,
			autoIncrement: true
		},
		name: {
			type: DataTypes.STRING(255),
			allowNull: false,
			field:"name",
		},
		campaignType: {
			type: DataTypes.STRING(255),
			allowNull: false,
			field:"campaign_type",
		}
    }

     return Campaign;
}
```

This problem fixed in this pull request.
