### PR TITLE
quotes required around type

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -564,7 +564,7 @@ const getMigration = function(actions)
         {
             if (k === 'seqType')
             {
-                vals.push('"type": '+obj[k]);
+                vals.push('"type": "'+obj[k] + '"');
                 continue;
             }
             


### PR DESCRIPTION
This should be backward compatible but we often get an error as `"type": TIMESTAMP WITH TIME ZONE,` isn't valid. It should be `"type": "TIMESTAMP WITH TIME ZONE",`