### PR TITLE
Ignore if defaultValue is null

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -121,7 +121,7 @@ const reverseSequelizeColType = function(col, prefix = 'Sequelize.')
 };
 
 const reverseSequelizeDefValueType = function(defaultValue, prefix = 'Sequelize.') 
-{ 
+{
     if (typeof defaultValue === 'object') {
         if (defaultValue.constructor && defaultValue.constructor.name) {
             return { internal: true, value: prefix + defaultValue.constructor.name };
@@ -187,7 +187,7 @@ const reverseModels = function(sequelize, models)
                     continue;
                 }
                 
-                if (property === 'defaultValue')
+                if (property === 'defaultValue' && attributes[column][property])
                 {
                     let _val = reverseSequelizeDefValueType(attributes[column][property]);
                     if (_val.notSupported)
@@ -567,7 +567,7 @@ const getMigration = function(actions)
                 continue;
             }
             
-            if (k === 'defaultValue')
+            if (k === 'defaultValue' && obj[k])
             {
                 if (obj[k].internal)
                 {


### PR DESCRIPTION
Fix error : 
```
/Users/ralmn/Developement/xxx/game/node_modules/sequelize-auto-migrations/lib/migrate.js:127
        if (defaultValue.constructor && defaultValue.constructor.name) {
                         ^

TypeError: Cannot read property 'constructor' of null
    at reverseSequelizeDefValueType (/Users/ralmn/Developement/xxx/game/node_modules/sequelize-auto-migrations/lib/migrate.js:127:26)
    at Object.reverseModels (/Users/ralmn/Developement/xxx/game/node_modules/sequelize-auto-migrations/lib/migrate.js:193:32)
    at Object.<anonymous> (/Users/ralmn/Developement/xxx/game/node_modules/sequelize-auto-migrations/bin/makemigration.js:76:31)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
    at startup (internal/bootstrap/node.js:285:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:739:3)
```