### PR TITLE
fix: use model.rawAttributes when model.attributes is removed

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -171,7 +171,7 @@ const reverseModels = function(sequelize, models)
     
     for (let model in models)
     {
-        let attributes = models[model].attributes;
+        let attributes = models[model].attributes || models[model].rawAttributes;
     
         for (let column in attributes)
         {


### PR DESCRIPTION
As of v5 Sequelize model.attributes has been removed. This just adds a fallback to model.rawAttributes.