### PR TITLE
Add "removeIndex" before "addIndex"

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -307,6 +307,12 @@ const parseDifference = function(previousState, currentState)
                         for(let _i in df.rhs.indexes)
                         {
                             actions.push(_.extend({
+                                actionType: 'removeIndex',
+                                tableName: tableName,
+                                depends: [ tableName ]
+                            }, _.clone(df.rhs.indexes[_i])));
+                            
+                            actions.push(_.extend({
                                 actionType: 'addIndex', 
                                 tableName: tableName,
                                 depends: [ tableName ]


### PR DESCRIPTION
This makes index creation operations idempotent. Migrations that create indexes now can be run multiple times without errors.