### PR TITLE
Adding support postgresql ARRAY support

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -99,6 +99,15 @@ const reverseSequelizeColType = function(col, prefix = 'Sequelize.')
             return prefix + 'GEOGRAPHY';
 
         case DataTypes.ARRAY.key:
+          const _type = attrObj.toString();
+          let arrayType;
+          if(_type === 'INTEGER[]' || _type === 'STRING[]') {
+            arrayType = prefix + _type.replace('[]', '');
+          } else {
+            arrayType = (col.seqType === 'Sequelize.ARRAY(Sequelize.INTEGER)') ? prefix + 'INTEGER' : prefix + 'STRING';
+          }
+          return prefix + `ARRAY(${arrayType})`;
+            
         case DataTypes.RANGE.key:
             console.warn(attrName + ' type not supported, you should make it by')
             return prefix + attrObj.toSql()
@@ -204,12 +213,24 @@ const reverseModels = function(sequelize, models)
                     delete attributes[column][property];
             }
             
-            if(typeof attributes[column]['type'] === 'undefined')
+            if(typeof attributes[column]['type'] === 'undefined') 
             {
+              if(!attributes[column]['seqType']) 
+              {
                 log(`[Not supported] Skip column with undefined type ${model}:${column}`);
                 delete attributes[column];
                 continue;
+              } else {
+                if(!['Sequelize.ARRAY(Sequelize.INTEGER)', 'Sequelize.ARRAY(Sequelize.STRING)'].includes(attributes[column]['seqType'])) {
+                  delete attributes[column];
+                  continue;
+                }
+                attributes[column]['type'] = {
+                  key: Sequelize.ARRAY.key
+                }
+              }
             }
+            
             let seqType = reverseSequelizeColType(attributes[column]);
             
             // NO virtual types in migration
@@ -787,4 +808,3 @@ const executeMigration = function(queryInterface, filename, pos, cb)
 };
 
 module.exports = { writeMigration, getMigration, sortActions, parseDifference, reverseModels, executeMigration };
-


### PR DESCRIPTION
Hi, i added support for postgres arrays.

```
# model.js
categories: {
     type: DataTypes.ARRAY(DataTypes.INTEGER),
     defaultValue: [],
}

# generated migration
"categories": {
     "type": Sequelize.ARRAY(Sequelize.INTEGER),
     "field": "categories",
     "defaultValue": Sequelize.Object
}

# postgres ddl
CREATE TABLE "***" (
    ...
    categories integer[],
   ...
);

```

works fine