### PR TITLE
Remove duplicates in migration actions

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -575,6 +575,7 @@ const sortActions = function(actions)
         return 0;    
     });    
     
+    // sort dependencies
     for (let k = 0; k <= actions.length ; k++)
         for (let i = 0; i < actions.length ; i++)
         {
@@ -606,6 +607,14 @@ const sortActions = function(actions)
     
             }
         }
+        
+    // remove duplicate changeColumns
+    for (let i = 0; i < actions.length ; i++)
+    {
+        if (_.isEqual(actions[i], actions[i-1])) {
+            actions.splice(i, 1);
+        }
+    }
 };
 
 


### PR DESCRIPTION
It makes the generated migration cleaner when you change two attributes of a column.