### PR TITLE
Create filename based on timestamp 

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -810,12 +810,25 @@ module.exports = {
 `;
 
     name = name.replace(' ', '_');
-    let filename = path.join(migrationsDir, revision + ((name != '') ? `-${name}` : '') + '.js');
+    let filename = path.join(migrationsDir, getCurrentYYYYMMDDHHmms() + '-' + revision + ((name != '') ? `-${name}` : '') + '.js');
 
     fs.writeFileSync(filename, template);
     
     return {filename, info};
 };
+
+const getCurrentYYYYMMDDHHmms = function () {
+  const date = new Date();
+  return [
+    date.getUTCFullYear(),
+    format(date.getUTCMonth() + 1),
+    format(date.getUTCDate()),
+    format(date.getUTCHours()),
+    format(date.getUTCMinutes()),
+    format(date.getUTCSeconds())
+  ].join('');
+}
+
 
 const executeMigration = function(queryInterface, filename, pos, cb)
 {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -817,6 +817,10 @@ module.exports = {
     return {filename, info};
 };
 
+const format = function (i) {
+  return parseInt(i, 10) < 10 ? '0' + i : i;
+}; 
+
 const getCurrentYYYYMMDDHHmms = function () {
   const date = new Date();
   return [
@@ -827,7 +831,7 @@ const getCurrentYYYYMMDDHHmms = function () {
     format(date.getUTCMinutes()),
     format(date.getUTCSeconds())
   ].join('');
-}
+};
 
 
 const executeMigration = function(queryInterface, filename, pos, cb)


### PR DESCRIPTION
This method is taken directly from sequelize: https://github.com/sequelize/cli/blob/master/src/helpers/path-helper.js

This way, when migrations are run, they will be run in the proper order. Currently, migration 9- runs before 11- due to the way unix handles filename sorting.

