### PR TITLE
Prevents bogus rhs detection from crashing when a model is updated

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -382,10 +382,13 @@ const parseDifference = function(previousState, currentState)
                 {
                     let tableName = df.path[0];
                     let index = _.clone(df.rhs);
-                    index.actionType = 'addIndex';
-                    index.tableName = tableName;
-                    index.depends = [ tableName ];
-                    actions.push(index);
+                    if (index)
+                    {
+                        index.actionType = 'addIndex';
+                        index.tableName = tableName;
+                        index.depends = [ tableName ];
+                        actions.push(index);
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
As outlined in this issue: https://github.com/flexxnn/sequelize-auto-migrations/issues/50

There are times where a RHS is picked up without any actual changes, and this crashes the program before it completes generating a migration. Skipping empty values seems to work fine. 