### PR TITLE
allow custom datatypes

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -11,7 +11,7 @@ let log                 = console.log;
 
 const reverseSequelizeColType = function(col, prefix = 'Sequelize.') 
 {
-    const attrName = col['type'].key
+    const attrName = (typeof col['type'].key === 'undefined') ? col['type'] : col['type'].key
     const attrObj = col.type
     const options = (col['type']['options']) ? col['type']['options'] : {}
     const DataTypes = Sequelize.DataTypes


### PR DESCRIPTION
Instead of Sequelize.undefined we now can get Sequelize.SOMETYPE which can be handled as custom datatype